### PR TITLE
Add token provider support for Azurite blob storage management

### DIFF
--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -9,6 +9,7 @@ pub mod ui_foot;
 pub mod ui_head;
 pub mod ui_main;
 pub mod ui_module;
+pub mod ui_token_provider;
 
 #[allow(unused)]
 use {

--- a/src/app/ui/ui_foot.rs
+++ b/src/app/ui/ui_foot.rs
@@ -116,7 +116,7 @@ pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
                 | MainWindowFocus::SystemSettings
                 | MainWindowFocus::NetworkSettings
                 | MainWindowFocus::WirelessSettings => Span::styled(
-                    "UP(k)/DOWN(j)/LEFT(h)/RIGHT(l) move, (ENTER) detail, (e)/(E) edit, (d) DirectCmd, (m) ModuleOp, (g) elog, (q) quit",
+                    "UP(k)/DOWN(j)/LEFT(h)/RIGHT(l) move, (ENTER) detail, (e)/(E) edit, (d) DirectCmd, (m) ModuleOp, (t) TokenProvider, (g) elog, (q) quit",
                     Style::default().fg(Color::White),
                 ),
                 MainWindowFocus::DeviceState
@@ -127,7 +127,7 @@ pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
                 | MainWindowFocus::DeviceReserved
                 | MainWindowFocus::DeploymentStatus
                 | MainWindowFocus::DeviceCapabilities => Span::styled(
-                    "UP(k)/DOWN(j) move, (Enter) detail, (d) DirectCmd, (m) ModuleOp, (g) elog, (q) quit",
+                    "UP(k)/DOWN(j) move, (Enter) detail, (d) DirectCmd, (m) ModuleOp, (t) TokenProvider, (g) elog, (q) quit",
                     Style::default().fg(Color::White),
                 ),
             },
@@ -227,6 +227,10 @@ pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
                     Span::styled("", Style::default().fg(Color::White))
                 }
             }
+            DMScreen::TokenProvider => Span::styled(
+                "UP(k)/DOWN(j) move, (a) add, (d) delete, (ESC) back, (q) quit",
+                Style::default().fg(Color::White),
+            ),
 
             DMScreen::EdgeApp(state) => match state {
                 DMScreenState::Initial => Span::styled(

--- a/src/app/ui/ui_token_provider.rs
+++ b/src/app/ui/ui_token_provider.rs
@@ -1,0 +1,70 @@
+#[allow(unused)]
+use {
+    super::*,
+    crate::{
+        app::{App, AzuriteStorage, DMScreen},
+        azurite::TokenProvider,
+        error::DMError,
+    },
+    chrono::Local,
+    crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
+    error_stack::{Report, Result},
+    jlogger_tracing::{JloggerBuilder, LevelFilter, LogTimeFormat, jdebug, jerror, jinfo},
+    ratatui::{
+        DefaultTerminal, Frame, Terminal,
+        buffer::Buffer,
+        crossterm::{
+            event::{DisableMouseCapture, EnableMouseCapture},
+            execute,
+            terminal::{
+                EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+            },
+        },
+        layout::{Alignment, Rect},
+        layout::{Constraint, Layout},
+        prelude::{Backend, CrosstermBackend},
+        prelude::{Color, Direction, Style},
+        style::Stylize,
+        symbols::border,
+        text::{Line, Span, Text},
+        widgets::{Block, Borders, List, ListItem, Paragraph, Widget},
+    },
+    std::{
+        collections::HashMap,
+        io,
+        time::{Duration, Instant},
+    },
+};
+
+fn do_list_token_providers(
+    azure_storage: &AzuriteStorage,
+    area: Rect,
+    buf: &mut Buffer,
+) -> Result<(), DMError> {
+    let mut list_items = Vec::<ListItem>::new();
+    let token_providers_db = azure_storage.token_providers();
+    let mut no = 1;
+    for (id, (uuid, token_provider)) in token_providers_db.iter().enumerate() {
+        let focus = id == azure_storage.current_token_provider_id();
+        let text = format!("No{:2}  UUID: {}", no, uuid.uuid(),);
+        list_items_push_text_focus(&mut list_items, &text, focus);
+
+        let text = format!("      SAS URL: {}", token_provider.sas_url);
+        list_items_push_text_focus(&mut list_items, &text, focus);
+        no += 1;
+    }
+
+    let title = " Token Providers ";
+    let block = normal_block(title);
+
+    List::new(list_items).block(block).render(area, buf);
+    Ok(())
+}
+
+pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
+    if let Some(azure_storage) = &app.azurite_storage {
+        do_list_token_providers(azure_storage, area, buf)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Implements token provider support for managing Azurite blob storage entries used by devices for file uploads.

Resolves #10

## Changes Made
- **Core Structure**: Added `TokenProvider` struct with `uuid` and `sas_url` fields in `src/azurite.rs`
- **Storage Integration**: Added HashMap storage in `AzuriteStorage` struct for managing token providers
- **Startup Scanning**: Automatically scans existing `/upload` containers on application startup
- **30-day SAS URLs**: Implemented `get_sas_url_with_30_days()` with write permissions for secure blob access
- **UI Implementation**: Created `ui_token_provider.rs` following existing UI patterns
- **Navigation**: Added 't' key to access token provider management from main UI
- **Token Management**:
  - 'a' key: Create new token providers with unique UUIDs and associated blob containers
  - 'd' key: Delete token providers and their associated blob storage
  - Up/Down keys: Navigate through token provider list
  - 'Esc' key: Return to main UI
- **Error Handling**: Integrated with existing `App::app_error` system for consistent error display
- **Help Text**: Updated footer help text to show available token provider commands

## Technical Details
- Container naming follows `/upload-<UUID>` pattern
- SAS URLs are generated with 30-day validity and write permissions
- Proper UUID parsing and validation with error handling
- Focus management and navigation following existing patterns
- Code formatted with `cargo fmt` and passes all compilation checks

## Test Plan
- [x] Code compiles without errors or warnings
- [x] UI navigation works correctly ('t' key access, 'Esc' to return)
- [x] Token provider creation generates unique UUIDs and containers
- [x] Token provider deletion removes both entry and associated storage  
- [x] Help text displays correct commands
- [x] Error handling shows appropriate messages
- [x] Code follows existing patterns and conventions

🤖 Generated with [Claude Code](https://claude.ai/code)