### PR TITLE
Add current token provider selection feature

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1284,6 +1284,15 @@ impl App {
                         }
                     }
                 }
+                KeyCode::Char('s') => {
+                    if let Some(azurite_storage) = &mut self.azurite_storage {
+                        if let Some(uuid) =
+                            azurite_storage.get_current_token_provider_by_highlight()
+                        {
+                            azurite_storage.set_current_token_provider(Some(uuid.clone()));
+                        }
+                    }
+                }
                 KeyCode::Esc => self.dm_screen_move_back(),
                 KeyCode::Char('q') => self.dm_screen_move_to(DMScreen::Exiting),
                 KeyCode::Up | KeyCode::Char('k') => {

--- a/src/app/ui/ui_foot.rs
+++ b/src/app/ui/ui_foot.rs
@@ -228,7 +228,7 @@ pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
                 }
             }
             DMScreen::TokenProvider => Span::styled(
-                "UP(k)/DOWN(j) move, (a) add, (d) delete, (ESC) back, (q) quit",
+                "UP(k)/DOWN(j) move, (a) add, (d) delete, (s) set current, (ESC) back, (q) quit",
                 Style::default().fg(Color::White),
             ),
 

--- a/src/app/ui/ui_token_provider.rs
+++ b/src/app/ui/ui_token_provider.rs
@@ -43,13 +43,16 @@ fn do_list_token_providers(
 ) -> Result<(), DMError> {
     let mut list_items = Vec::<ListItem>::new();
     let token_providers_db = azure_storage.token_providers();
+    let current_token_provider_uuid = azure_storage.get_current_token_provider();
     let mut no = 1;
     for (id, (uuid, token_provider)) in token_providers_db.iter().enumerate() {
         let focus = id == azure_storage.current_token_provider_id();
-        let text = format!("No{:2}  UUID: {}", no, uuid.uuid(),);
+        let is_current = current_token_provider_uuid == Some(uuid);
+        let star_mark = if is_current { "*" } else { " " };
+        let text = format!("{}No{:2}  UUID: {}", star_mark, no, uuid.uuid(),);
         list_items_push_text_focus(&mut list_items, &text, focus);
 
-        let text = format!("      SAS URL: {}", token_provider.sas_url);
+        let text = format!("       SAS URL: {}", token_provider.sas_url);
         list_items_push_text_focus(&mut list_items, &text, focus);
         no += 1;
     }


### PR DESCRIPTION
## Summary
- Add current token provider selection functionality to device-monitor
- Allow users to set a current token provider that can be referenced for log settings and other configurations
- Provide visual feedback with star marking in the UI

## Changes
- **AzureStorage**: Add `current_token_provider` field (Option<UUID>) to track the selected provider
- **Key Handler**: Implement 's' key to set currently highlighted token provider as current
- **UI Enhancement**: Display star (*) at the beginning of lines for the current token provider
- **Deletion Logic**: Reset current provider to None when the selected provider is deleted
- **Helper Methods**: Add getter/setter methods for current token provider management

## Test plan
- [x] Build verification: Code compiles successfully
- [x] Unit tests: All existing tests pass (39/39)
- [x] Format check: Code formatting follows project standards
- [x] Functional verification: Implementation follows all requirements in set_current_token_provider.md

## Requirements Fulfilled
✅ Add current_token_provider field to AzuriteStorage (Option<UUID>)  
✅ Initialize as None  
✅ Press 's' key to set current token provider in UI  
✅ Reset to None when selected token provider is deleted  
✅ Mark current provider with star (*) in UI  
✅ Set currently highlighted provider as current  
✅ No confirmation needed, visual feedback only  
✅ Handle empty provider list gracefully  
✅ Overwrite previous selection without confirmation  

🤖 Generated with [Claude Code](https://claude.ai/code)

fix #13 