### PR TITLE
Integrate token provider selection with log configuration UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 Cargo.lock
 .aider*
+.requirements/*
+.vim/*

--- a/src/app/ui/ui_foot.rs
+++ b/src/app/ui/ui_foot.rs
@@ -227,10 +227,19 @@ pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
                     Span::styled("", Style::default().fg(Color::White))
                 }
             }
-            DMScreen::TokenProvider => Span::styled(
-                "UP(k)/DOWN(j) move, (a) add, (d) delete, (s) set current, (ESC) back, (q) quit",
-                Style::default().fg(Color::White),
-            ),
+            DMScreen::TokenProvider => {
+                if app.token_provider_for_config.is_some() {
+                    Span::styled(
+                        "UP(k)/DOWN(j) move, (ENTER) select, (ESC) back, (q) quit",
+                        Style::default().fg(Color::White),
+                    )
+                } else {
+                    Span::styled(
+                        "UP(k)/DOWN(j) move, (a) add, (d) delete, (s) set current, (ESC) back, (q) quit",
+                        Style::default().fg(Color::White),
+                    )
+                }
+            }
 
             DMScreen::EdgeApp(state) => match state {
                 DMScreenState::Initial => Span::styled(

--- a/src/app/ui/ui_foot.rs
+++ b/src/app/ui/ui_foot.rs
@@ -230,7 +230,7 @@ pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
             DMScreen::TokenProvider => {
                 if app.token_provider_for_config.is_some() {
                     Span::styled(
-                        "UP(k)/DOWN(j) move, (ENTER) select, (ESC) back, (q) quit",
+                        "UP(k)/DOWN(j) move, (ENTER) select, (a) add, (d) delete, (ESC) back, (q) quit",
                         Style::default().fg(Color::White),
                     )
                 } else {


### PR DESCRIPTION
## Summary
This PR implements the integration between the existing token provider UI and the log configuration UI, allowing users to select token providers for storage name settings instead of manual text input.

## Changes
- **Enhanced App Structure**: Added `token_provider_for_config` field to track when token provider UI is accessed from config UI
- **Smart Edit Detection**: Modified config UI edit flow ('a'/'i' keys) to detect log storage config keys and redirect to token provider UI
- **Token Provider Selection**: Added Enter key support in token provider UI for selecting and returning UUID to config
- **Dynamic UI Instructions**: Updated footer to show context-appropriate instructions based on usage mode
- **Seamless Navigation**: Maintains smooth transition between config and token provider screens

## Affected Config Keys
When editing these configuration keys, users will now be directed to the token provider selection UI:
- `ConfigKey::AllLogSettingStorageName`
- `ConfigKey::MainLogSettingStorageName` 
- `ConfigKey::SensorLogSettingStorageName`
- `ConfigKey::CompanionFwLogSettingStorageName`

## User Experience
1. User navigates to log configuration and presses 'a' or 'i' on a storage name field
2. Application automatically transitions to token provider selection UI
3. User navigates with Up/Down keys and selects with Enter
4. Selected token provider UUID is immediately set as the config value
5. UI seamlessly returns to log configuration screen

## Technical Implementation
- Uses existing token provider UI infrastructure (`src/app/ui/ui_token_provider.rs`)
- Leverages `TokenProvider.uuid.uuid()` method for UUID string extraction
- No breaking changes to existing functionality
- Maintains all existing token provider operations (add, delete, set current)

## Testing
- ✅ Compilation successful with `cargo check` and `cargo build`
- ✅ Code formatted with `cargo fmt`
- ✅ All existing token provider functionality preserved
- ✅ Config UI behavior unchanged for non-storage-name fields

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/code)