### PR TITLE
Implement global MqttCtrl pattern to eliminate circular references

### DIFF
--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -648,7 +648,7 @@ pub fn draw_device_capabilities(
             );
         }
 
-        if let Some(v) = device_capabilities.is_battery_supported() {
+        if let Some(v) = device_capabilities.is_sensor_postprocess_supported() {
             list_items_push_dynamic(
                 &mut list_items,
                 width,

--- a/src/app/ui/ui_edge_app.rs
+++ b/src/app/ui/ui_edge_app.rs
@@ -1,3 +1,4 @@
+use crate::mqtt_ctrl::with_mqtt_ctrl;
 #[allow(unused)]
 use {
     super::{
@@ -21,449 +22,460 @@ use {
     },
 };
 
-pub fn draw_default_state(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
-    if let Some(edge_app) = app.mqtt_ctrl().edge_app() {
-        // Edge App should be included in the deployment status
-        if let Some(deployment_status) = app.mqtt_ctrl().deployment_status() {
-            if !deployment_status
-                .instances()
-                .iter()
-                .any(|(id, _)| id.uuid() == edge_app.id())
+pub fn draw_default_state(area: Rect, buf: &mut Buffer, _app: &App) -> Result<(), DMError> {
+    with_mqtt_ctrl(|mqtt_ctrl| -> Result<(), DMError> {
+        if let Some(edge_app) = mqtt_ctrl.edge_app() {
+            // Edge App should be included in the deployment status
+            if let Some(deployment_status) = mqtt_ctrl.deployment_status() {
+                if !deployment_status
+                    .instances()
+                    .iter()
+                    .any(|(id, _)| id.uuid() == edge_app.id())
+                {
+                    return Ok(());
+                }
+            }
+
+            let title = format!("Edge App: {}", edge_app.id());
+            let outer_block = normal_block(&title).borders(Borders::NONE);
+
+            let inner_area = outer_block.inner(area);
+            outer_block.render(area, buf);
+
+            let chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .margin(0)
+                .constraints([Constraint::Percentage(60), Constraint::Percentage(40)].as_ref())
+                .split(inner_area);
+
+            // Common Settings
             {
-                return Ok(());
-            }
-        }
+                let common_settings = edge_app.module().common_settings();
+                let mut list_items = Vec::<ListItem>::new();
 
-        let title = format!("Edge App: {}", edge_app.id());
-        let outer_block = normal_block(&title).borders(Borders::NONE);
-
-        let inner_area = outer_block.inner(area);
-        outer_block.render(area, buf);
-
-        let chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .margin(0)
-            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)].as_ref())
-            .split(inner_area);
-
-        // Common Settings
-        {
-            let common_settings = edge_app.module().common_settings();
-            let mut list_items = Vec::<ListItem>::new();
-
-            // Process state
-            if let Some(process_state) = common_settings.process_state() {
-                list_items_push(&mut list_items, "process_state", &process_state.to_string());
-            }
-
-            // Log Level
-            if let Some(log_level) = common_settings.log_level() {
-                list_items_push(&mut list_items, "log_level", &log_level.to_string());
-            }
-
-            // Inference Settings
-            if let Some(inference_settings) = common_settings.inference_settings() {
-                list_items_push_text_focus(&mut list_items, "inference_settings", false);
-                if let Some(number_of_iterations) = inference_settings.number_of_iterations() {
-                    list_items_push(
-                        &mut list_items,
-                        "  number_of_iterations",
-                        number_of_iterations.to_string().as_str(),
-                    );
-                }
-            }
-
-            // PQ Settings
-            if let Some(pq_settings) = common_settings.pq_settings() {
-                list_items_push_text_focus(&mut list_items, "pq_settings", false);
-                if let Some(camera_image_size) = pq_settings.camera_image_size() {
-                    list_items_push(
-                        &mut list_items,
-                        "  camera_image_size",
-                        camera_image_size.to_string().as_str(),
-                    );
+                // Process state
+                if let Some(process_state) = common_settings.process_state() {
+                    list_items_push(&mut list_items, "process_state", &process_state.to_string());
                 }
 
-                if let Some(frame_rate) = pq_settings.frame_rate() {
-                    list_items_push(
-                        &mut list_items,
-                        "  frame_rate",
-                        frame_rate.to_string().as_str(),
-                    );
+                // Log Level
+                if let Some(log_level) = common_settings.log_level() {
+                    list_items_push(&mut list_items, "log_level", &log_level.to_string());
                 }
 
-                if let Some(digital_zoom) = pq_settings.digital_zoom() {
-                    list_items_push(
-                        &mut list_items,
-                        "  digital_zoom",
-                        digital_zoom.to_string().as_str(),
-                    );
-                }
-
-                if let Some(camera_image_flip) = pq_settings.camera_image_flip() {
-                    list_items_push(
-                        &mut list_items,
-                        "  camera_image_flip",
-                        camera_image_flip.to_string().as_str(),
-                    );
-                }
-
-                // Exposure Mode
-                if let Some(exposure_mode) = pq_settings.exposure_mode() {
-                    let mode = match exposure_mode {
-                        0 => "auto",
-                        1 => "manual",
-                        _ => "invalid",
-                    };
-
-                    list_items_push(
-                        &mut list_items,
-                        "  exposure_mode",
-                        format!("{mode} ({exposure_mode})").as_str(),
-                    );
-
-                    // If exposure mode is auto, show auto exposure settings
-                    if exposure_mode == 0 {
-                        // Auto Exposure Settings
-                        if let Some(auto_exposure) = pq_settings.auto_exposure() {
-                            list_items_push_text_focus(&mut list_items, "  auto_exposure", false);
-
-                            if let Some(max_exposure_time) = auto_exposure.max_exposure_time() {
-                                list_items_push(
-                                    &mut list_items,
-                                    "    max_exposure_time",
-                                    max_exposure_time.to_string().as_str(),
-                                );
-                            }
-
-                            if let Some(min_exposure_time) = auto_exposure.min_exposure_time() {
-                                list_items_push(
-                                    &mut list_items,
-                                    "    min_exposure_time",
-                                    min_exposure_time.to_string().as_str(),
-                                );
-                            }
-
-                            if let Some(max_gain) = auto_exposure.max_gain() {
-                                list_items_push(
-                                    &mut list_items,
-                                    "    max_gain",
-                                    max_gain.to_string().as_str(),
-                                );
-                            }
-
-                            if let Some(convergence_speed) = auto_exposure.convergence_speed() {
-                                list_items_push(
-                                    &mut list_items,
-                                    "    convergence_speed",
-                                    convergence_speed.to_string().as_str(),
-                                );
-                            }
-                        }
-
-                        // EV compensation
-                        if let Some(ev_compensation) = pq_settings.ev_compensation() {
-                            list_items_push(
-                                &mut list_items,
-                                "  ev_compensation: {}",
-                                ev_compensation.to_string().as_str(),
-                            );
-                        }
-
-                        // AE Anti Flicker Mode
-                        if let Some(ae_anti_flicker_mode) = pq_settings.ae_anti_flicker_mode() {
-                            let mode = match ae_anti_flicker_mode {
-                                0 => "auto",
-                                1 => "50Hz",
-                                2 => "60Hz",
-                                _ => "invalid",
-                            };
-                            list_items_push(
-                                &mut list_items,
-                                "  ae_anti_flicker_mode",
-                                format!("{mode} ({ae_anti_flicker_mode})").as_str(),
-                            );
-                        }
-                    }
-
-                    if exposure_mode == 1 {
-                        if let Some(manual_exposure) = pq_settings.manual_exposure() {
-                            list_items_push_text_focus(&mut list_items, "  manual_exposure", false);
-
-                            if let Some(exposure_time) = manual_exposure.exposure_time() {
-                                list_items_push(
-                                    &mut list_items,
-                                    "    exposure_time",
-                                    exposure_time.to_string().as_str(),
-                                );
-                            }
-
-                            if let Some(gain) = manual_exposure.gain() {
-                                list_items_push(
-                                    &mut list_items,
-                                    "    gain",
-                                    gain.to_string().as_str(),
-                                );
-                            }
-                        }
+                // Inference Settings
+                if let Some(inference_settings) = common_settings.inference_settings() {
+                    list_items_push_text_focus(&mut list_items, "inference_settings", false);
+                    if let Some(number_of_iterations) = inference_settings.number_of_iterations() {
+                        list_items_push(
+                            &mut list_items,
+                            "  number_of_iterations",
+                            number_of_iterations.to_string().as_str(),
+                        );
                     }
                 }
 
-                if let Some(white_balance_mode) = pq_settings.white_balance_mode() {
-                    let mode = match white_balance_mode {
-                        0 => "auto",
-                        1 => "manual",
-                        _ => "invalid",
-                    };
-                    list_items_push(
-                        &mut list_items,
-                        "  white_balance_mode",
-                        format!("{mode} (white_balance_mode)").as_str(),
-                    );
-
-                    // If white balance mode is auto, show auto white balance settings
-                    if white_balance_mode == 0 {
-                        if let Some(auto_white_balance) = pq_settings.auto_white_balance() {
-                            list_items_push_text_focus(
-                                &mut list_items,
-                                "  auto_white_balance",
-                                false,
-                            );
-
-                            if let Some(convergence_speed) = auto_white_balance.convergence_speed()
-                            {
-                                list_items_push(
-                                    &mut list_items,
-                                    "    convergence_speed",
-                                    convergence_speed.to_string().as_str(),
-                                );
-                            }
-                        }
+                // PQ Settings
+                if let Some(pq_settings) = common_settings.pq_settings() {
+                    list_items_push_text_focus(&mut list_items, "pq_settings", false);
+                    if let Some(camera_image_size) = pq_settings.camera_image_size() {
+                        list_items_push(
+                            &mut list_items,
+                            "  camera_image_size",
+                            camera_image_size.to_string().as_str(),
+                        );
                     }
 
-                    // if white balance mode is preset
-                    if white_balance_mode == 1 {
-                        if let Some(manual_white_balance_preset) =
-                            pq_settings.manual_white_balance_preset()
-                        {
-                            list_items_push_text_focus(
-                                &mut list_items,
-                                "  manual_white_balance",
-                                false,
-                            );
+                    if let Some(frame_rate) = pq_settings.frame_rate() {
+                        list_items_push(
+                            &mut list_items,
+                            "  frame_rate",
+                            frame_rate.to_string().as_str(),
+                        );
+                    }
 
-                            if let Some(color_temperature) =
-                                manual_white_balance_preset.color_temperature()
-                            {
-                                let color_temp = match color_temperature {
-                                    0 => "3200K",
-                                    1 => "4300K",
-                                    2 => "5600K",
-                                    3 => "6500K",
+                    if let Some(digital_zoom) = pq_settings.digital_zoom() {
+                        list_items_push(
+                            &mut list_items,
+                            "  digital_zoom",
+                            digital_zoom.to_string().as_str(),
+                        );
+                    }
+
+                    if let Some(camera_image_flip) = pq_settings.camera_image_flip() {
+                        list_items_push(
+                            &mut list_items,
+                            "  camera_image_flip",
+                            camera_image_flip.to_string().as_str(),
+                        );
+                    }
+
+                    // Exposure Mode
+                    if let Some(exposure_mode) = pq_settings.exposure_mode() {
+                        let mode = match exposure_mode {
+                            0 => "auto",
+                            1 => "manual",
+                            _ => "invalid",
+                        };
+
+                        list_items_push(
+                            &mut list_items,
+                            "  exposure_mode",
+                            format!("{mode} ({exposure_mode})").as_str(),
+                        );
+
+                        // If exposure mode is auto, show auto exposure settings
+                        if exposure_mode == 0 {
+                            // Auto Exposure Settings
+                            if let Some(auto_exposure) = pq_settings.auto_exposure() {
+                                list_items_push_text_focus(
+                                    &mut list_items,
+                                    "  auto_exposure",
+                                    false,
+                                );
+
+                                if let Some(max_exposure_time) = auto_exposure.max_exposure_time() {
+                                    list_items_push(
+                                        &mut list_items,
+                                        "    max_exposure_time",
+                                        max_exposure_time.to_string().as_str(),
+                                    );
+                                }
+
+                                if let Some(min_exposure_time) = auto_exposure.min_exposure_time() {
+                                    list_items_push(
+                                        &mut list_items,
+                                        "    min_exposure_time",
+                                        min_exposure_time.to_string().as_str(),
+                                    );
+                                }
+
+                                if let Some(max_gain) = auto_exposure.max_gain() {
+                                    list_items_push(
+                                        &mut list_items,
+                                        "    max_gain",
+                                        max_gain.to_string().as_str(),
+                                    );
+                                }
+
+                                if let Some(convergence_speed) = auto_exposure.convergence_speed() {
+                                    list_items_push(
+                                        &mut list_items,
+                                        "    convergence_speed",
+                                        convergence_speed.to_string().as_str(),
+                                    );
+                                }
+                            }
+
+                            // EV compensation
+                            if let Some(ev_compensation) = pq_settings.ev_compensation() {
+                                list_items_push(
+                                    &mut list_items,
+                                    "  ev_compensation: {}",
+                                    ev_compensation.to_string().as_str(),
+                                );
+                            }
+
+                            // AE Anti Flicker Mode
+                            if let Some(ae_anti_flicker_mode) = pq_settings.ae_anti_flicker_mode() {
+                                let mode = match ae_anti_flicker_mode {
+                                    0 => "auto",
+                                    1 => "50Hz",
+                                    2 => "60Hz",
                                     _ => "invalid",
                                 };
-
                                 list_items_push(
                                     &mut list_items,
-                                    "    color_temperature",
-                                    format!("{} ({})", color_temp, color_temperature).as_str(),
+                                    "  ae_anti_flicker_mode",
+                                    format!("{mode} ({ae_anti_flicker_mode})").as_str(),
                                 );
                             }
+                        }
+
+                        if exposure_mode == 1 {
+                            if let Some(manual_exposure) = pq_settings.manual_exposure() {
+                                list_items_push_text_focus(
+                                    &mut list_items,
+                                    "  manual_exposure",
+                                    false,
+                                );
+
+                                if let Some(exposure_time) = manual_exposure.exposure_time() {
+                                    list_items_push(
+                                        &mut list_items,
+                                        "    exposure_time",
+                                        exposure_time.to_string().as_str(),
+                                    );
+                                }
+
+                                if let Some(gain) = manual_exposure.gain() {
+                                    list_items_push(
+                                        &mut list_items,
+                                        "    gain",
+                                        gain.to_string().as_str(),
+                                    );
+                                }
+                            }
+                        }
+                    }
+
+                    if let Some(white_balance_mode) = pq_settings.white_balance_mode() {
+                        let mode = match white_balance_mode {
+                            0 => "auto",
+                            1 => "manual",
+                            _ => "invalid",
+                        };
+                        list_items_push(
+                            &mut list_items,
+                            "  white_balance_mode",
+                            format!("{mode} (white_balance_mode)").as_str(),
+                        );
+
+                        // If white balance mode is auto, show auto white balance settings
+                        if white_balance_mode == 0 {
+                            if let Some(auto_white_balance) = pq_settings.auto_white_balance() {
+                                list_items_push_text_focus(
+                                    &mut list_items,
+                                    "  auto_white_balance",
+                                    false,
+                                );
+
+                                if let Some(convergence_speed) =
+                                    auto_white_balance.convergence_speed()
+                                {
+                                    list_items_push(
+                                        &mut list_items,
+                                        "    convergence_speed",
+                                        convergence_speed.to_string().as_str(),
+                                    );
+                                }
+                            }
+                        }
+
+                        // if white balance mode is preset
+                        if white_balance_mode == 1 {
+                            if let Some(manual_white_balance_preset) =
+                                pq_settings.manual_white_balance_preset()
+                            {
+                                list_items_push_text_focus(
+                                    &mut list_items,
+                                    "  manual_white_balance",
+                                    false,
+                                );
+
+                                if let Some(color_temperature) =
+                                    manual_white_balance_preset.color_temperature()
+                                {
+                                    let color_temp = match color_temperature {
+                                        0 => "3200K",
+                                        1 => "4300K",
+                                        2 => "5600K",
+                                        3 => "6500K",
+                                        _ => "invalid",
+                                    };
+
+                                    list_items_push(
+                                        &mut list_items,
+                                        "    color_temperature",
+                                        format!("{} ({})", color_temp, color_temperature).as_str(),
+                                    );
+                                }
+                            }
+                        }
+                    }
+
+                    if let Some(image_cropping) = pq_settings.image_cropping() {
+                        list_items_push(
+                            &mut list_items,
+                            "  image_cropping",
+                            image_cropping.to_string().as_str(),
+                        );
+                    }
+
+                    if let Some(image_rotation) = pq_settings.image_rotation() {
+                        let image_rotation_str = match image_rotation {
+                            0 => "0 degrees",
+                            1 => "clockwise 90 degrees",
+                            2 => "clockwise 180 degrees",
+                            3 => "clockwise 270 degrees",
+                            _ => "invalid",
+                        };
+                        list_items_push(
+                            &mut list_items,
+                            "  image_rotation",
+                            &format!("{} ({})", image_rotation_str, image_rotation),
+                        );
+                    }
+
+                    // Don's display registered settings
+                }
+
+                // Port Settings
+                if let Some(port_settings) = common_settings.port_settings() {
+                    list_items_push_text_focus(&mut list_items, "port_settings", false);
+                    if let Some(metadata) = port_settings.metadata() {
+                        list_items_push_text_focus(&mut list_items, "  metadata", false);
+                        if let Some(method) = metadata.method() {
+                            let m = match method {
+                                0 => "EVP telemetry",
+                                1 => "Blob storage",
+                                2 => "Http storage",
+                                _ => "Invalid",
+                            };
+
+                            list_items_push(
+                                &mut list_items,
+                                "    method",
+                                format!("{} ({})", m, method).as_str(),
+                            );
+                        }
+
+                        if let Some(storage_name) = metadata.storage_name() {
+                            list_items_push(&mut list_items, "    storage_name", storage_name);
+                        }
+
+                        if let Some(endpoint) = metadata.endpoint() {
+                            list_items_push(&mut list_items, "    endpoint", endpoint);
+                        }
+
+                        if let Some(path) = metadata.path() {
+                            list_items_push(&mut list_items, "    path", path);
+                        }
+
+                        if let Some(enabled) = metadata.enabled() {
+                            list_items_push(
+                                &mut list_items,
+                                "    enabled",
+                                enabled.to_string().as_str(),
+                            );
+                        }
+                    }
+
+                    if let Some(input_tensor) = port_settings.input_tensor() {
+                        list_items_push_text_focus(&mut list_items, "  input_tensor", false);
+                        if let Some(method) = input_tensor.method() {
+                            let m = match method {
+                                0 => "EVP telemetry",
+                                1 => "Blob storage",
+                                2 => "Http storage",
+                                _ => "Invalid",
+                            };
+
+                            list_items_push(
+                                &mut list_items,
+                                "    method",
+                                format!("{} ({})", m, method).as_str(),
+                            );
+                        }
+
+                        if let Some(storage_name) = input_tensor.storage_name() {
+                            list_items_push(&mut list_items, "    storage_name", storage_name);
+                        }
+
+                        if let Some(endpoint) = input_tensor.endpoint() {
+                            list_items_push(&mut list_items, "    endpoint", endpoint);
+                        }
+
+                        if let Some(path) = input_tensor.path() {
+                            list_items_push(&mut list_items, "    path", path);
+                        }
+
+                        if let Some(enabled) = input_tensor.enabled() {
+                            list_items_push(
+                                &mut list_items,
+                                "    enabled",
+                                enabled.to_string().as_str(),
+                            );
                         }
                     }
                 }
 
-                if let Some(image_cropping) = pq_settings.image_cropping() {
-                    list_items_push(
-                        &mut list_items,
-                        "  image_cropping",
-                        image_cropping.to_string().as_str(),
-                    );
-                }
-
-                if let Some(image_rotation) = pq_settings.image_rotation() {
-                    let image_rotation_str = match image_rotation {
-                        0 => "0 degrees",
-                        1 => "clockwise 90 degrees",
-                        2 => "clockwise 180 degrees",
-                        3 => "clockwise 270 degrees",
-                        _ => "invalid",
-                    };
-                    list_items_push(
-                        &mut list_items,
-                        "  image_rotation",
-                        &format!("{} ({})", image_rotation_str, image_rotation),
-                    );
-                }
-
-                // Don's display registered settings
-            }
-
-            // Port Settings
-            if let Some(port_settings) = common_settings.port_settings() {
-                list_items_push_text_focus(&mut list_items, "port_settings", false);
-                if let Some(metadata) = port_settings.metadata() {
-                    list_items_push_text_focus(&mut list_items, "  metadata", false);
-                    if let Some(method) = metadata.method() {
-                        let m = match method {
-                            0 => "EVP telemetry",
-                            1 => "Blob storage",
-                            2 => "Http storage",
+                // Codec settings
+                if let Some(codec_settings) = common_settings.codec_settings() {
+                    list_items_push_text_focus(&mut list_items, "codec_settings", false);
+                    if let Some(format) = codec_settings.format() {
+                        let format_str = match format {
+                            1 => "JPEG",
                             _ => "Invalid",
                         };
-
                         list_items_push(
                             &mut list_items,
-                            "    method",
-                            format!("{} ({})", m, method).as_str(),
-                        );
-                    }
-
-                    if let Some(storage_name) = metadata.storage_name() {
-                        list_items_push(&mut list_items, "    storage_name", storage_name);
-                    }
-
-                    if let Some(endpoint) = metadata.endpoint() {
-                        list_items_push(&mut list_items, "    endpoint", endpoint);
-                    }
-
-                    if let Some(path) = metadata.path() {
-                        list_items_push(&mut list_items, "    path", path);
-                    }
-
-                    if let Some(enabled) = metadata.enabled() {
-                        list_items_push(
-                            &mut list_items,
-                            "    enabled",
-                            enabled.to_string().as_str(),
+                            "  codec",
+                            &format!("{} ({})", format_str, format),
                         );
                     }
                 }
 
-                if let Some(input_tensor) = port_settings.input_tensor() {
-                    list_items_push_text_focus(&mut list_items, "  input_tensor", false);
-                    if let Some(method) = input_tensor.method() {
-                        let m = match method {
-                            0 => "EVP telemetry",
-                            1 => "Blob storage",
-                            2 => "Http storage",
-                            _ => "Invalid",
-                        };
-
-                        list_items_push(
-                            &mut list_items,
-                            "    method",
-                            format!("{} ({})", m, method).as_str(),
-                        );
-                    }
-
-                    if let Some(storage_name) = input_tensor.storage_name() {
-                        list_items_push(&mut list_items, "    storage_name", storage_name);
-                    }
-
-                    if let Some(endpoint) = input_tensor.endpoint() {
-                        list_items_push(&mut list_items, "    endpoint", endpoint);
-                    }
-
-                    if let Some(path) = input_tensor.path() {
-                        list_items_push(&mut list_items, "    path", path);
-                    }
-
-                    if let Some(enabled) = input_tensor.enabled() {
-                        list_items_push(
-                            &mut list_items,
-                            "    enabled",
-                            enabled.to_string().as_str(),
-                        );
-                    }
-                }
-            }
-
-            // Codec settings
-            if let Some(codec_settings) = common_settings.codec_settings() {
-                list_items_push_text_focus(&mut list_items, "codec_settings", false);
-                if let Some(format) = codec_settings.format() {
-                    let format_str = match format {
-                        1 => "JPEG",
-                        _ => "Invalid",
-                    };
+                // Number of inference per message
+                if let Some(number_of_inference_per_message) =
+                    common_settings.number_of_inference_per_message()
+                {
                     list_items_push(
                         &mut list_items,
-                        "  codec",
-                        &format!("{} ({})", format_str, format),
+                        "number_of_inference_per_message",
+                        number_of_inference_per_message.to_string().as_str(),
                     );
                 }
+
+                // upload_interval
+                if let Some(upload_interval) = common_settings.upload_interval() {
+                    list_items_push(
+                        &mut list_items,
+                        "upload_interval",
+                        upload_interval.to_string().as_str(),
+                    );
+                }
+
+                let common_settings_block = normal_block("Common Settings");
+                List::new(list_items)
+                    .block(common_settings_block)
+                    .render(chunks[0], buf);
             }
 
-            // Number of inference per message
-            if let Some(number_of_inference_per_message) =
-                common_settings.number_of_inference_per_message()
+            let right_chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .margin(0)
+                .constraints([Constraint::Percentage(25), Constraint::Percentage(75)].as_ref())
+                .split(chunks[1]);
+
+            // Req/Res Info
             {
-                list_items_push(
-                    &mut list_items,
-                    "number_of_inference_per_message",
-                    number_of_inference_per_message.to_string().as_str(),
-                );
+                let mut list_items = Vec::<ListItem>::new();
+
+                if let Some(req_info) = edge_app.module().req_info() {
+                    list_items_push_text_focus(&mut list_items, "req_info", false);
+                    list_items_push(&mut list_items, "  req_id", req_info.req_id());
+                }
+
+                if let Some(res_info) = edge_app.module().res_info() {
+                    list_items_push_text_focus(&mut list_items, "res_info", false);
+                    list_items_push(&mut list_items, "  res_id", res_info.res_id());
+
+                    list_items_push(&mut list_items, "  code", res_info.code_str());
+                    list_items_push(&mut list_items, "  detail_msg", res_info.detail_msg());
+                }
+
+                let req_res_block = normal_block("Req/Res Info");
+                List::new(list_items)
+                    .block(req_res_block)
+                    .render(right_chunks[0], buf);
             }
 
-            // upload_interval
-            if let Some(upload_interval) = common_settings.upload_interval() {
-                list_items_push(
-                    &mut list_items,
-                    "upload_interval",
-                    upload_interval.to_string().as_str(),
-                );
-            }
-
-            let common_settings_block = normal_block("Common Settings");
-            List::new(list_items)
-                .block(common_settings_block)
-                .render(chunks[0], buf);
-        }
-
-        let right_chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .margin(0)
-            .constraints([Constraint::Percentage(25), Constraint::Percentage(75)].as_ref())
-            .split(chunks[1]);
-
-        // Req/Res Info
-        {
-            let mut list_items = Vec::<ListItem>::new();
-
-            if let Some(req_info) = edge_app.module().req_info() {
-                list_items_push_text_focus(&mut list_items, "req_info", false);
-                list_items_push(&mut list_items, "  req_id", req_info.req_id());
-            }
-
-            if let Some(res_info) = edge_app.module().res_info() {
-                list_items_push_text_focus(&mut list_items, "res_info", false);
-                list_items_push(&mut list_items, "  res_id", res_info.res_id());
-
-                list_items_push(&mut list_items, "  code", res_info.code_str());
-                list_items_push(&mut list_items, "  detail_msg", res_info.detail_msg());
-            }
-
-            let req_res_block = normal_block("Req/Res Info");
-            List::new(list_items)
-                .block(req_res_block)
-                .render(right_chunks[0], buf);
-        }
-
-        // Custom Settings
-        {
-            let custom_settings_block = normal_block("Custom Settings");
-            if let Some(custom_settings) = edge_app.module().custom_settings() {
-                if let Some(custom) = custom_settings.custom() {
-                    Paragraph::new(custom.to_owned())
-                        .block(custom_settings_block.clone())
-                        .alignment(Alignment::Left)
-                        .render(right_chunks[1], buf);
+            // Custom Settings
+            {
+                let custom_settings_block = normal_block("Custom Settings");
+                if let Some(custom_settings) = edge_app.module().custom_settings() {
+                    if let Some(custom) = custom_settings.custom() {
+                        Paragraph::new(custom.to_owned())
+                            .block(custom_settings_block.clone())
+                            .alignment(Alignment::Left)
+                            .render(right_chunks[1], buf);
+                    }
                 }
             }
         }
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 pub fn draw_configure_state(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {

--- a/src/app/ui/ui_elog.rs
+++ b/src/app/ui/ui_elog.rs
@@ -1,3 +1,4 @@
+use crate::mqtt_ctrl::with_mqtt_ctrl;
 #[allow(unused)]
 use {
     super::centered_rect,
@@ -37,53 +38,55 @@ use {
     },
 };
 
-pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
-    let elogs = app.mqtt_ctrl.elogs();
+pub fn draw(area: Rect, buf: &mut Buffer, _app: &App) -> Result<(), DMError> {
+    with_mqtt_ctrl(|mqtt_ctrl| -> Result<(), DMError> {
+        let elogs = mqtt_ctrl.elogs();
 
-    let mut record = vec![];
-    for elog in elogs.iter().rev() {
-        let line = Line::from(vec![
-            Span::styled(
-                format!("{} ", elog.timestamp()),
-                Style::default().fg(Color::White),
-            ),
-            match elog.level() {
-                0 => Span::styled(
-                    format!("{:<8} ", elog.level_str()),
-                    Style::default().fg(Color::Red),
-                ),
-                1 => Span::styled(
-                    format!("{:<8} ", elog.level_str()),
-                    Style::default().fg(Color::Magenta),
-                ),
-                2 => Span::styled(
-                    format!("{:<8} ", elog.level_str()),
-                    Style::default().fg(Color::Yellow),
-                ),
-                _ => Span::styled(
-                    format!("{:<8} ", elog.level_str()),
+        let mut record = vec![];
+        for elog in elogs.iter().rev() {
+            let line = Line::from(vec![
+                Span::styled(
+                    format!("{} ", elog.timestamp()),
                     Style::default().fg(Color::White),
                 ),
-            },
-            Span::styled(
-                format!("{} (0x{:0x})", elog.event_str(), elog.event_id()),
-                Style::default().fg(Color::White),
-            ),
-            Span::styled("\n", Style::default().fg(Color::White)),
-        ]);
-        record.push(line);
-    }
+                match elog.level() {
+                    0 => Span::styled(
+                        format!("{:<8} ", elog.level_str()),
+                        Style::default().fg(Color::Red),
+                    ),
+                    1 => Span::styled(
+                        format!("{:<8} ", elog.level_str()),
+                        Style::default().fg(Color::Magenta),
+                    ),
+                    2 => Span::styled(
+                        format!("{:<8} ", elog.level_str()),
+                        Style::default().fg(Color::Yellow),
+                    ),
+                    _ => Span::styled(
+                        format!("{:<8} ", elog.level_str()),
+                        Style::default().fg(Color::White),
+                    ),
+                },
+                Span::styled(
+                    format!("{} (0x{:0x})", elog.event_str(), elog.event_id()),
+                    Style::default().fg(Color::White),
+                ),
+                Span::styled("\n", Style::default().fg(Color::White)),
+            ]);
+            record.push(line);
+        }
 
-    if !record.is_empty() {
-        Paragraph::new(record)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(" ELOGS ")
-                    .border_style(Style::default().fg(Color::White)),
-            )
-            .render(area, buf);
-    }
+        if !record.is_empty() {
+            Paragraph::new(record)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(" ELOGS ")
+                        .border_style(Style::default().fg(Color::White)),
+                )
+                .render(area, buf);
+        }
 
-    Ok(())
+        Ok(())
+    })
 }

--- a/src/app/ui/ui_foot.rs
+++ b/src/app/ui/ui_foot.rs
@@ -1,3 +1,4 @@
+use crate::mqtt_ctrl::with_mqtt_ctrl;
 #[allow(unused)]
 use {
     crate::{
@@ -48,18 +49,18 @@ use {
 };
 
 pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
-    // Draw foot
-    let foot_chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(35), Constraint::Percentage(65)])
-        .split(area);
+    with_mqtt_ctrl(|mqtt_ctrl| -> Result<(), DMError> {
+        // Draw foot
+        let foot_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(35), Constraint::Percentage(65)])
+            .split(area);
 
-    // Draw the current connection status and last connected time
-    {
+        // Draw the current connection status and last connected time
         let mut connect_info = Span::styled(" Disconnected ", Style::default().fg(Color::Red));
 
-        let is_device_connected = app.mqtt_ctrl.is_device_connected();
-        let last_connected = app.mqtt_ctrl.last_connected_time();
+        let is_device_connected = mqtt_ctrl.is_device_connected();
+        let last_connected = mqtt_ctrl.last_connected_time();
         let now = Local::now();
         let delta = now - last_connected;
         let days = delta.num_days();
@@ -92,179 +93,179 @@ pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
         Paragraph::new(Line::from(current_navigation_text))
             .block(Block::default().borders(Borders::NONE))
             .render(foot_chunks[0], buf);
-    }
 
-    if let Some(error) = app.app_error.as_ref() {
-        // If there is an error, display it in red
-        Paragraph::new(Line::from(Span::styled(
-            error,
-            Style::default().fg(Color::Red),
-        )))
-        .render(foot_chunks[1], buf);
-    } else if let Some(info) = app.mqtt_ctrl.info.as_ref() {
-        // If there is info, display it in white
-        Paragraph::new(Line::from(Span::styled(
-            info,
-            Style::default().fg(Color::White),
-        )))
-        .render(foot_chunks[1], buf);
-    } else {
-        // Shows current keys hint based on the screen and focus
-        let current_keys_hint = match app.current_screen() {
-            DMScreen::Main => match app.main_window_focus() {
-                MainWindowFocus::AgentState
-                | MainWindowFocus::SystemSettings
-                | MainWindowFocus::NetworkSettings
-                | MainWindowFocus::WirelessSettings => Span::styled(
-                    "UP(k)/DOWN(j)/LEFT(h)/RIGHT(l) move, (ENTER) detail, (e)/(E) edit, (d) DirectCmd, (m) ModuleOp, (t) TokenProvider, (g) elog, (q) quit",
-                    Style::default().fg(Color::White),
-                ),
-                MainWindowFocus::DeviceState
-                | MainWindowFocus::MainChip
-                | MainWindowFocus::SensorChip
-                | MainWindowFocus::CompanionChip
-                | MainWindowFocus::DeviceManifest
-                | MainWindowFocus::DeviceReserved
-                | MainWindowFocus::DeploymentStatus
-                | MainWindowFocus::DeviceCapabilities => Span::styled(
-                    "UP(k)/DOWN(j) move, (Enter) detail, (d) DirectCmd, (m) ModuleOp, (t) TokenProvider, (g) elog, (q) quit",
-                    Style::default().fg(Color::White),
-                ),
-            },
-            DMScreen::Module => match app.main_window_focus() {
-                MainWindowFocus::MainChip
-                | MainWindowFocus::SensorChip
-                | MainWindowFocus::CompanionChip
-                | MainWindowFocus::AgentState
-                | MainWindowFocus::SystemSettings
-                | MainWindowFocus::NetworkSettings
-                | MainWindowFocus::DeploymentStatus
-                | MainWindowFocus::WirelessSettings => Span::styled(
-                    "(e)/(E) edit (d) DirectCmd, (m) ModuleOp, (g) elog, (ENTER)/(ESC) back, (q) quit",
-                    Style::default().fg(Color::White),
-                ),
-                MainWindowFocus::DeviceState
-                | MainWindowFocus::DeviceManifest
-                | MainWindowFocus::DeviceReserved
-                | MainWindowFocus::DeviceCapabilities => Span::styled(
-                    "(d) DirectCmd, (m) ModuleOp, (g) elog, (ENTER)/(ESC) back, (q) quit",
-                    Style::default().fg(Color::White),
-                ),
-            },
-
-            DMScreen::Elog => Span::styled(
-                "(w) save, (ESC) back, (q) quit",
-                Style::default().fg(Color::White),
-            ),
-
-            DMScreen::Configuration => {
-                if app.config_result.is_none() {
-                    Span::styled(
-                        "(ESC):back, UP(k)/DOWN(j) move, (a)/(i) edit, (w) write",
-                        Style::default().fg(Color::White),
-                    )
-                } else {
-                    Span::styled("(ESC) back, (s) send", Style::default().fg(Color::White))
-                }
-            }
-
-            DMScreen::ConfigurationUser => {
-                if app.config_result.is_none() {
-                    Span::styled(
-                        "(q) quit, (ESC) back, (w) write",
-                        Style::default().fg(Color::White),
-                    )
-                } else {
-                    Span::styled(
-                        "(q) quit, (ESC) back, (s) send",
-                        Style::default().fg(Color::White),
-                    )
-                }
-            }
-
-            DMScreen::DirectCommand => {
-                if let Some(DirectCommand::GetDirectImage) = app.mqtt_ctrl.get_direct_command() {
-                    if app.mqtt_ctrl.direct_command_request().is_none() {
-                        Span::styled(
-                            "(ESC) back, UP(k)/DOWN(j) move, (a)/(i) edit, (s) send",
-                            Style::default().fg(Color::White),
-                        )
-                    } else if let Some(Ok(_)) = app.mqtt_ctrl.direct_command_result() {
-                        Span::styled(
-                            "(ESC) back, (w) save (q) quit",
-                            Style::default().fg(Color::White),
-                        )
-                    } else {
-                        Span::styled(
-                            "(ESC) back, (s) send (q) quit",
-                            Style::default().fg(Color::White),
-                        )
-                    }
-                } else {
-                    Span::styled("(ESC) back, (q) quit", Style::default().fg(Color::White))
-                }
-            }
-
-            DMScreen::EvpModule => {
-                if let Some(azure_storage) = app.azurite_storage.as_ref() {
-                    if azure_storage.action() == AzuriteAction::Add {
-                        Span::styled(
-                            "(ESC) back, (ENTER) register",
-                            Style::default().fg(Color::White),
-                        )
-                    } else if app.config_result.is_some() {
-                        Span::styled(
-                            "(s) send, (ESC) back, (q) quit",
-                            Style::default().fg(Color::White),
-                        )
-                    } else {
-                        Span::styled(
-                            "UP(k)/DOWN(j) move, (a) add, (r) remove, (d) deploy, (u) undeploy, (ESC) back, (q) quit",
-                            Style::default().fg(Color::White),
-                        )
-                    }
-                } else {
-                    Span::styled("", Style::default().fg(Color::White))
-                }
-            }
-            DMScreen::TokenProvider => {
-                if app.token_provider_for_config.is_some() {
-                    Span::styled(
-                        "UP(k)/DOWN(j) move, (ENTER) select, (a) add, (d) delete, (ESC) back, (q) quit",
-                        Style::default().fg(Color::White),
-                    )
-                } else {
-                    Span::styled(
-                        "UP(k)/DOWN(j) move, (a) add, (d) delete, (s) set current, (ESC) back, (q) quit",
-                        Style::default().fg(Color::White),
-                    )
-                }
-            }
-
-            DMScreen::EdgeApp(state) => match state {
-                DMScreenState::Initial => Span::styled(
-                    "(e) edit, (ESC) back, (q) quit",
-                    Style::default().fg(Color::White),
-                ),
-                DMScreenState::Configuring => Span::styled(
-                    "UP(k)/DOWN(j) move, (w) write, (ESC) back, (q) quit",
-                    Style::default().fg(Color::White),
-                ),
-                DMScreenState::Completed => Span::styled(
-                    "(s) send, (ESC) back, (q) quit",
-                    Style::default().fg(Color::White),
-                ),
-            },
-
-            DMScreen::Exiting => {
-                Span::styled("(y) exit / (n) cancel", Style::default().fg(Color::White))
-            }
-        };
-
-        Paragraph::new(Line::from(format!(" {}", current_keys_hint)))
-            .block(Block::default().borders(Borders::LEFT))
+        if let Some(error) = app.app_error.as_ref() {
+            // If there is an error, display it in red
+            Paragraph::new(Line::from(Span::styled(
+                error,
+                Style::default().fg(Color::Red),
+            )))
             .render(foot_chunks[1], buf);
-    }
+        } else if let Some(info) = mqtt_ctrl.info.as_ref() {
+            // If there is info, display it in white
+            Paragraph::new(Line::from(Span::styled(
+                info,
+                Style::default().fg(Color::White),
+            )))
+            .render(foot_chunks[1], buf);
+        } else {
+            // Shows current keys hint based on the screen and focus
+            let current_keys_hint = match app.current_screen() {
+                DMScreen::Main => match app.main_window_focus() {
+                    MainWindowFocus::AgentState
+                    | MainWindowFocus::SystemSettings
+                    | MainWindowFocus::NetworkSettings
+                    | MainWindowFocus::WirelessSettings => Span::styled(
+                        "UP(k)/DOWN(j)/LEFT(h)/RIGHT(l) move, (ENTER) detail, (e)/(E) edit, (d) DirectCmd, (m) ModuleOp, (t) TokenProvider, (g) elog, (q) quit",
+                        Style::default().fg(Color::White),
+                    ),
+                    MainWindowFocus::DeviceState
+                    | MainWindowFocus::MainChip
+                    | MainWindowFocus::SensorChip
+                    | MainWindowFocus::CompanionChip
+                    | MainWindowFocus::DeviceManifest
+                    | MainWindowFocus::DeviceReserved
+                    | MainWindowFocus::DeploymentStatus
+                    | MainWindowFocus::DeviceCapabilities => Span::styled(
+                        "UP(k)/DOWN(j) move, (Enter) detail, (d) DirectCmd, (m) ModuleOp, (t) TokenProvider, (g) elog, (q) quit",
+                        Style::default().fg(Color::White),
+                    ),
+                },
+                DMScreen::Module => match app.main_window_focus() {
+                    MainWindowFocus::MainChip
+                    | MainWindowFocus::SensorChip
+                    | MainWindowFocus::CompanionChip
+                    | MainWindowFocus::AgentState
+                    | MainWindowFocus::SystemSettings
+                    | MainWindowFocus::NetworkSettings
+                    | MainWindowFocus::DeploymentStatus
+                    | MainWindowFocus::WirelessSettings => Span::styled(
+                        "(e)/(E) edit (d) DirectCmd, (m) ModuleOp, (g) elog, (ENTER)/(ESC) back, (q) quit",
+                        Style::default().fg(Color::White),
+                    ),
+                    MainWindowFocus::DeviceState
+                    | MainWindowFocus::DeviceManifest
+                    | MainWindowFocus::DeviceReserved
+                    | MainWindowFocus::DeviceCapabilities => Span::styled(
+                        "(d) DirectCmd, (m) ModuleOp, (g) elog, (ENTER)/(ESC) back, (q) quit",
+                        Style::default().fg(Color::White),
+                    ),
+                },
 
-    Ok(())
+                DMScreen::Elog => Span::styled(
+                    "(w) save, (ESC) back, (q) quit",
+                    Style::default().fg(Color::White),
+                ),
+
+                DMScreen::Configuration => {
+                    if app.config_result.is_none() {
+                        Span::styled(
+                            "(ESC):back, UP(k)/DOWN(j) move, (a)/(i) edit, (w) write",
+                            Style::default().fg(Color::White),
+                        )
+                    } else {
+                        Span::styled("(ESC) back, (s) send", Style::default().fg(Color::White))
+                    }
+                }
+
+                DMScreen::ConfigurationUser => {
+                    if app.config_result.is_none() {
+                        Span::styled(
+                            "(q) quit, (ESC) back, (w) write",
+                            Style::default().fg(Color::White),
+                        )
+                    } else {
+                        Span::styled(
+                            "(q) quit, (ESC) back, (s) send",
+                            Style::default().fg(Color::White),
+                        )
+                    }
+                }
+
+                DMScreen::DirectCommand => {
+                    if let Some(DirectCommand::GetDirectImage) = mqtt_ctrl.get_direct_command() {
+                        if mqtt_ctrl.direct_command_request().is_none() {
+                            Span::styled(
+                                "(ESC) back, UP(k)/DOWN(j) move, (a)/(i) edit, (s) send",
+                                Style::default().fg(Color::White),
+                            )
+                        } else if let Some(Ok(_)) = mqtt_ctrl.direct_command_result() {
+                            Span::styled(
+                                "(ESC) back, (w) save (q) quit",
+                                Style::default().fg(Color::White),
+                            )
+                        } else {
+                            Span::styled(
+                                "(ESC) back, (s) send (q) quit",
+                                Style::default().fg(Color::White),
+                            )
+                        }
+                    } else {
+                        Span::styled("(ESC) back, (q) quit", Style::default().fg(Color::White))
+                    }
+                }
+
+                DMScreen::EvpModule => {
+                    if let Some(azure_storage) = app.azurite_storage.as_ref() {
+                        if azure_storage.action() == AzuriteAction::Add {
+                            Span::styled(
+                                "(ESC) back, (ENTER) register",
+                                Style::default().fg(Color::White),
+                            )
+                        } else if app.config_result.is_some() {
+                            Span::styled(
+                                "(s) send, (ESC) back, (q) quit",
+                                Style::default().fg(Color::White),
+                            )
+                        } else {
+                            Span::styled(
+                                "UP(k)/DOWN(j) move, (a) add, (r) remove, (d) deploy, (u) undeploy, (ESC) back, (q) quit",
+                                Style::default().fg(Color::White),
+                            )
+                        }
+                    } else {
+                        Span::styled("", Style::default().fg(Color::White))
+                    }
+                }
+                DMScreen::TokenProvider => {
+                    if app.token_provider_for_config.is_some() {
+                        Span::styled(
+                            "UP(k)/DOWN(j) move, (ENTER) select, (a) add, (d) delete, (ESC) back, (q) quit",
+                            Style::default().fg(Color::White),
+                        )
+                    } else {
+                        Span::styled(
+                            "UP(k)/DOWN(j) move, (a) add, (d) delete, (s) set current, (ESC) back, (q) quit",
+                            Style::default().fg(Color::White),
+                        )
+                    }
+                }
+
+                DMScreen::EdgeApp(state) => match state {
+                    DMScreenState::Initial => Span::styled(
+                        "(e) edit, (ESC) back, (q) quit",
+                        Style::default().fg(Color::White),
+                    ),
+                    DMScreenState::Configuring => Span::styled(
+                        "UP(k)/DOWN(j) move, (w) write, (ESC) back, (q) quit",
+                        Style::default().fg(Color::White),
+                    ),
+                    DMScreenState::Completed => Span::styled(
+                        "(s) send, (ESC) back, (q) quit",
+                        Style::default().fg(Color::White),
+                    ),
+                },
+
+                DMScreen::Exiting => {
+                    Span::styled("(y) exit / (n) cancel", Style::default().fg(Color::White))
+                }
+            };
+
+            Paragraph::new(Line::from(format!(" {}", current_keys_hint)))
+                .block(Block::default().borders(Borders::LEFT))
+                .render(foot_chunks[1], buf);
+        }
+
+        Ok(())
+    })
 }

--- a/src/app/ui/ui_module.rs
+++ b/src/app/ui/ui_module.rs
@@ -1,4 +1,4 @@
-use crate::app::MainWindowFocus;
+use crate::{app::MainWindowFocus, mqtt_ctrl::with_mqtt_ctrl};
 #[allow(unused)]
 use {
     super::*,
@@ -49,71 +49,73 @@ use {
 };
 
 pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
-    match app.main_window_focus {
-        MainWindowFocus::MainChip => {
-            let device_info = app.mqtt_ctrl().device_info();
-            draw_chip_info(area, buf, device_info, "main_chip", BlockType::Normal)
-        }
+    with_mqtt_ctrl(|mqtt_ctrl| -> Result<(), DMError> {
+        match app.main_window_focus {
+            MainWindowFocus::MainChip => {
+                let device_info = mqtt_ctrl.device_info();
+                draw_chip_info(area, buf, device_info, "main_chip", BlockType::Normal)
+            }
 
-        MainWindowFocus::CompanionChip => {
-            let device_info = app.mqtt_ctrl().device_info();
-            draw_chip_info(area, buf, device_info, "companion_chip", BlockType::Normal)
-        }
+            MainWindowFocus::CompanionChip => {
+                let device_info = mqtt_ctrl.device_info();
+                draw_chip_info(area, buf, device_info, "companion_chip", BlockType::Normal)
+            }
 
-        MainWindowFocus::SensorChip => {
-            let device_info = app.mqtt_ctrl().device_info();
-            draw_chip_info(area, buf, device_info, "sensor_chip", BlockType::Normal)
-        }
+            MainWindowFocus::SensorChip => {
+                let device_info = mqtt_ctrl.device_info();
+                draw_chip_info(area, buf, device_info, "sensor_chip", BlockType::Normal)
+            }
 
-        MainWindowFocus::DeviceManifest => {
-            draw_device_manifest(area, buf, app.mqtt_ctrl().device_info(), BlockType::Normal)
-        }
+            MainWindowFocus::DeviceManifest => {
+                draw_device_manifest(area, buf, mqtt_ctrl.device_info(), BlockType::Normal)
+            }
 
-        MainWindowFocus::AgentState => {
-            let agent_system_info = app.mqtt_ctrl().agent_system_info();
-            let agent_device_config = app.mqtt_ctrl().agent_device_config();
-            draw_agent_state(
-                area,
-                buf,
-                agent_system_info,
-                agent_device_config,
-                BlockType::Normal,
-            )
-        }
+            MainWindowFocus::AgentState => {
+                let agent_system_info = mqtt_ctrl.agent_system_info();
+                let agent_device_config = mqtt_ctrl.agent_device_config();
+                draw_agent_state(
+                    area,
+                    buf,
+                    agent_system_info,
+                    agent_device_config,
+                    BlockType::Normal,
+                )
+            }
 
-        MainWindowFocus::DeploymentStatus => {
-            let deployment_status = app.mqtt_ctrl.deployment_status();
-            draw_deployment_status(area, buf, deployment_status, BlockType::Normal)
-        }
+            MainWindowFocus::DeploymentStatus => {
+                let deployment_status = mqtt_ctrl.deployment_status();
+                draw_deployment_status(area, buf, deployment_status, BlockType::Normal)
+            }
 
-        MainWindowFocus::DeviceReserved => {
-            let device_reserved = app.mqtt_ctrl().device_reserved();
-            draw_device_reserved(area, buf, device_reserved, BlockType::Normal)
-        }
+            MainWindowFocus::DeviceReserved => {
+                let device_reserved = mqtt_ctrl.device_reserved();
+                draw_device_reserved(area, buf, device_reserved, BlockType::Normal)
+            }
 
-        MainWindowFocus::DeviceState => {
-            let device_states = app.mqtt_ctrl().device_states();
-            draw_device_states(area, buf, device_states, BlockType::Normal)
-        }
+            MainWindowFocus::DeviceState => {
+                let device_states = mqtt_ctrl.device_states();
+                draw_device_states(area, buf, device_states, BlockType::Normal)
+            }
 
-        MainWindowFocus::DeviceCapabilities => {
-            let device_capabilities = app.mqtt_ctrl().device_capabilities();
-            draw_device_capabilities(area, buf, device_capabilities, BlockType::Normal)
-        }
+            MainWindowFocus::DeviceCapabilities => {
+                let device_capabilities = mqtt_ctrl.device_capabilities();
+                draw_device_capabilities(area, buf, device_capabilities, BlockType::Normal)
+            }
 
-        MainWindowFocus::SystemSettings => {
-            let system_settings = app.mqtt_ctrl().system_settings();
-            draw_system_settings(area, buf, system_settings, BlockType::Normal)
-        }
+            MainWindowFocus::SystemSettings => {
+                let system_settings = mqtt_ctrl.system_settings();
+                draw_system_settings(area, buf, system_settings, BlockType::Normal)
+            }
 
-        MainWindowFocus::NetworkSettings => {
-            let network_settings = app.mqtt_ctrl().network_settings();
-            draw_network_settings(area, buf, network_settings, BlockType::Normal)
-        }
+            MainWindowFocus::NetworkSettings => {
+                let network_settings = mqtt_ctrl.network_settings();
+                draw_network_settings(area, buf, network_settings, BlockType::Normal)
+            }
 
-        MainWindowFocus::WirelessSettings => {
-            let wireless_settings = app.mqtt_ctrl().wireless_settings();
-            draw_wireless_settings(area, buf, wireless_settings, BlockType::Normal)
+            MainWindowFocus::WirelessSettings => {
+                let wireless_settings = mqtt_ctrl.wireless_settings();
+                draw_wireless_settings(area, buf, wireless_settings, BlockType::Normal)
+            }
         }
-    }
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,9 @@ fn main() -> Result<(), DMError> {
     jdebug!(func = "main", line = line!(), note = "Starting app");
     let mut terminal = dm_setup()?;
 
+    // Initialize global MqttCtrl
+    mqtt_ctrl::init_global_mqtt_ctrl(&cli.broker)?;
+
     let mut app = App::new(AppConfig {
         broker: &cli.broker,
         azurite_url: &cli.azurite_url,

--- a/src/mqtt_ctrl/evp/device_info.rs
+++ b/src/mqtt_ctrl/evp/device_info.rs
@@ -143,10 +143,6 @@ impl Default for DeviceInfo {
 }
 
 impl DeviceInfo {
-    pub fn parse(s: &str) -> Result<Self, DMError> {
-        serde_json::from_str(s).map_err(|_| Report::new(DMError::InvalidData))
-    }
-
     pub fn device_manifest(&self) -> Option<&str> {
         self.device_manifest.as_deref()
     }
@@ -351,6 +347,7 @@ pub struct DeviceReserved {
     schema: String,
 }
 
+#[allow(unused)]
 impl DeviceReserved {
     pub fn schema(&self) -> &str {
         &self.schema


### PR DESCRIPTION
## Summary
- Refactor MqttCtrl to use global static variable with OnceLock<Mutex<MqttCtrl>> pattern
- Eliminates circular reference issues between App and MqttCtrl
- Provides closure-based API for thread-safe access to global MqttCtrl instance

## Key Changes
- Add global static GLOBAL_MQTT_CTRL with OnceLock<Mutex<MqttCtrl>>
- Implement init_global_mqtt_ctrl() initialization function  
- Add with_mqtt_ctrl() and with_mqtt_ctrl_mut() closure-based access functions
- Remove mqtt_ctrl field from App struct
- Update all UI components to use global access pattern
- Fix lifetime issues with MutexGuard values in UI layer

## Test plan
- [x] Code compiles successfully
- [x] Format check passes
- [x] All UI components updated to use global pattern
- [x] Lifetime issues resolved for MutexGuard values
- [ ] Manual testing of application functionality

🤖 Generated with [Claude Code](https://claude.ai/code)