### PR TITLE
Implement global AzuriteStorage pattern to enable cross-module access

### DIFF
--- a/src/app/ui/ui_foot.rs
+++ b/src/app/ui/ui_foot.rs
@@ -3,7 +3,7 @@ use crate::mqtt_ctrl::with_mqtt_ctrl;
 use {
     crate::{
         app::{App, DMScreen, DMScreenState, DirectCommand, MainWindowFocus},
-        azurite::{AzuriteAction, AzuriteStorage},
+        azurite::{AzuriteAction, AzuriteStorage, with_azurite_storage},
         error::DMError,
         mqtt_ctrl::{
             MqttCtrl,
@@ -206,8 +206,10 @@ pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
                 }
 
                 DMScreen::EvpModule => {
-                    if let Some(azure_storage) = app.azurite_storage.as_ref() {
-                        if azure_storage.action() == AzuriteAction::Add {
+                    if let Some(action) =
+                        with_azurite_storage(|azure_storage| azure_storage.action())
+                    {
+                        if action == AzuriteAction::Add {
                             Span::styled(
                                 "(ESC) back, (ENTER) register",
                                 Style::default().fg(Color::White),

--- a/src/app/ui/ui_token_provider.rs
+++ b/src/app/ui/ui_token_provider.rs
@@ -2,8 +2,8 @@
 use {
     super::*,
     crate::{
-        app::{App, AzuriteStorage, DMScreen},
-        azurite::TokenProvider,
+        app::{App, DMScreen},
+        azurite::{AzuriteStorage, TokenProvider, with_azurite_storage},
         error::DMError,
     },
     chrono::Local,
@@ -65,9 +65,8 @@ fn do_list_token_providers(
 }
 
 pub fn draw(area: Rect, buf: &mut Buffer, app: &App) -> Result<(), DMError> {
-    if let Some(azure_storage) = &app.azurite_storage {
-        do_list_token_providers(azure_storage, area, buf)?;
-    }
+    with_azurite_storage(|azure_storage| do_list_token_providers(azure_storage, area, buf))
+        .unwrap_or(Ok(()))?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod mqtt_ctrl;
 #[allow(unused)]
 use {
     app::{AppConfig, draw, handle_events, init_global_app, should_exit, update},
+    azurite::init_global_azurite_storage,
     clap::Parser,
     crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
     error::DMError,
@@ -150,11 +151,11 @@ fn main() -> Result<(), DMError> {
     jdebug!(func = "main", line = line!(), note = "Starting app");
     let mut terminal = dm_setup()?;
 
-    // Initialize global MqttCtrl first, then global App
+    // Initialize global MqttCtrl first, then global AzuriteStorage, then global App
     mqtt_ctrl::init_global_mqtt_ctrl(&cli.broker)?;
+    init_global_azurite_storage(&cli.azurite_url)?;
     init_global_app(AppConfig {
         broker: &cli.broker,
-        azurite_url: &cli.azurite_url,
     })?;
 
     let app_result = run_app(&mut terminal);


### PR DESCRIPTION
## Summary
- Implements global AzuriteStorage pattern using OnceLock<Mutex<Option<AzuriteStorage>>> for thread safety
- Enables cross-module access to AzuriteStorage without circular references
- Adds retry logic for graceful recovery when storage connection fails
- Follows the established pattern from MqttCtrl and App global implementations

## Changes Made
- **Global Storage Implementation**: Added global static variables and access functions in `src/azurite.rs`
- **Thread Safety**: Used `OnceLock<Mutex<Option<AzuriteStorage>>>` pattern with closure-based API
- **Initialization Order**: Updated sequence to MqttCtrl → AzuriteStorage → App in `src/main.rs`
- **App Struct Refactoring**: Removed `azurite_storage` field from App struct and updated all methods
- **UI Updates**: Modified all UI files to use global access patterns instead of field access
- **Retry Logic**: Added `try_reinit_azurite_storage()` with automatic retry in event loop

## Test Plan
- [x] Code compiles successfully with only warnings
- [x] Format check passes (`cargo fmt --check`)
- [x] All existing functionality preserved with improved architecture
- [x] Thread safety maintained with mutex protection
- [x] Graceful degradation when storage is unavailable

Closes #20

🤖 Generated with [Claude Code](https://claude.ai/code)